### PR TITLE
fix: image_tag filename

### DIFF
--- a/app/views/codes/index.html.erb
+++ b/app/views/codes/index.html.erb
@@ -54,7 +54,7 @@
           <% if code.image.present? %>
             <%= image_tag code.image.url , class:"object-cover w-full" %>
           <% else %>
-            <%= image_tag "nodata" %>
+            <%= image_tag "nodata.png" %>
           <% end %>
       </figure>
       <div class="card-body p-4 gap-0">


### PR DESCRIPTION
本番環境でnodata画像を参照出来なかったため、image_tagに記載していた画像パスに拡張子を追加。